### PR TITLE
Update vitest to 0.0.123

### DIFF
--- a/vitest/package.json
+++ b/vitest/package.json
@@ -22,7 +22,7 @@
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.6",
     "less": "4.1.2",
-    "vite": "2.7.9",
-    "vitest": "0.0.122"
+    "vite": "2.7.10",
+    "vitest": "0.0.123"
   }
 }


### PR DESCRIPTION
Performance fix in vitest 0.0.123 also depends on vite 2.7.10.

I'd expect this to now be faster than Jest as would be expected, and curious about comparison to Jasmine.

Can you rerun your tests and update results after PR is merged?